### PR TITLE
Make share SSR capable and navigation aware

### DIFF
--- a/donation-tracker/gatsby-config.ts
+++ b/donation-tracker/gatsby-config.ts
@@ -1,4 +1,6 @@
 import type { GatsbyConfig } from "gatsby";
+import PageConfiguration from "./src/config";
+
 
 const config: GatsbyConfig = {
   siteMetadata: {
@@ -7,7 +9,7 @@ const config: GatsbyConfig = {
     description:
       "Collecting needed things for the people in Ukraine.",
     image: "/static/media/tim-mossholder-BQa--UCtFqg-unsplash_1200.jpg", // Path to the image placed in the 'static' folder, in the project's root directory.
-    siteUrl: "https://helpukraine.ingelheim.mobi" // No trailing slash allowed!
+    siteUrl: PageConfiguration.PageUrl
   },
   plugins: ["gatsby-plugin-sass", "gatsby-plugin-image", "gatsby-plugin-react-helmet", "gatsby-plugin-sitemap", {
     resolve: 'gatsby-plugin-manifest',

--- a/donation-tracker/src/components/layout.tsx
+++ b/donation-tracker/src/components/layout.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { navigate } from 'gatsby';
+import { useLocation } from '@reach/router';
 
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
@@ -29,7 +30,7 @@ const mainLevelPages = [
 const titleText = '#StandWithUkraine';
 
 const LayoutModule = (props: any) => {
-  
+
   const generateShareLinks = () => {
     // default to configured Page URL (for SSR in node)
     let shareUrl = PageConfiguration.PageUrl;
@@ -44,6 +45,11 @@ const LayoutModule = (props: any) => {
       },
     ];
   }
+  const location = useLocation();
+  React.useEffect(() => {
+    // make sure we update the share links on navigation changes (without this they stay with the link at load time)
+    setShareLinks(generateShareLinks());
+  }, [location]);
   const [anchorElNav, setAnchorElNav] = React.useState<null | HTMLElement>(null);
   const [shareLinks, setShareLinks] = React.useState<any>(generateShareLinks());
   const handleOpenNavMenu = (event: React.MouseEvent<HTMLElement>) => {
@@ -57,8 +63,6 @@ const LayoutModule = (props: any) => {
     event.preventDefault();
     navigate(itemLink);
     setAnchorElNav(null);
-    // make sure we update the share links (without this they stay with the link at load time)
-    setShareLinks(generateShareLinks());
   };
 
   const [anchorElShare, setAnchorElShare] = React.useState<null | HTMLElement>(null);

--- a/donation-tracker/src/components/layout.tsx
+++ b/donation-tracker/src/components/layout.tsx
@@ -18,6 +18,7 @@ import '@fontsource/roboto-slab';
 
 import '../styles.scss';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
+import PageConfiguration from '../config';
 
 /* ToDo: import this from a central location */
 const mainLevelPages = [
@@ -26,15 +27,25 @@ const mainLevelPages = [
   { name: 'Imprint / Impressum', link: '/imprint/' },
 ];
 const titleText = '#StandWithUkraine';
-const shareLinks = [
-  {
-    name: 'Mail',
-    link: () => `mailto:?subject=${titleText}&body=Please join us at ${window.location.href} with helping people in Ukraine`,
-  },
-];
 
 const LayoutModule = (props: any) => {
+  
+  const generateShareLinks = () => {
+    // default to configured Page URL (for SSR in node)
+    let shareUrl = PageConfiguration.PageUrl;
+    // if runtime (window is defined) override with actual page URL
+    if (typeof window !== 'undefined') {
+      shareUrl = window.location.href;
+    }
+    return [
+      {
+        name: 'Mail',
+        link: () => `mailto:?subject=${titleText}&body=Please join us at ${shareUrl} with helping people in Ukraine`,
+      },
+    ];
+  }
   const [anchorElNav, setAnchorElNav] = React.useState<null | HTMLElement>(null);
+  const [shareLinks, setShareLinks] = React.useState<any>(generateShareLinks());
   const handleOpenNavMenu = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorElNav(event.currentTarget);
   };
@@ -46,6 +57,8 @@ const LayoutModule = (props: any) => {
     event.preventDefault();
     navigate(itemLink);
     setAnchorElNav(null);
+    // make sure we update the share links (without this they stay with the link at load time)
+    setShareLinks(generateShareLinks());
   };
 
   const [anchorElShare, setAnchorElShare] = React.useState<null | HTMLElement>(null);
@@ -159,7 +172,7 @@ const LayoutModule = (props: any) => {
                 open={Boolean(anchorElShare)}
                 onClose={handleCloseShareMenu}
               >
-                {shareLinks.map((share, index) => (
+                {shareLinks.map((share: any, index: number) => (
                   <MenuItem
                     href={share.link()}
                     key={`shareMenuItem${index.toString()}`}

--- a/donation-tracker/src/config.ts
+++ b/donation-tracker/src/config.ts
@@ -19,6 +19,11 @@ export default class PageConfiguration {
    */
   static AutoRefresh: boolean = true;
 
+  /**
+   * The URL for the page - NO trailing / allowed
+   */
+  static PageUrl: string = 'https://helpukraine.ingelheim.mobi';
+
   static ImprintContact = {
     NameOfResponsible: 'Firstname Lastname',
     AddressLine1: 'Gateway 10',


### PR DESCRIPTION
- using plain `window.location.href` broke build as node does not know the `window` object at build time -> fixed
- link stayed always with the entry URL (the one that you loaded the page with); now it uses the current page you are on by adding a state change on ~~nay~~ any navigation happening