### PR TITLE
Improve translations & add language switch

### DIFF
--- a/donation-tracker/locales/de/translation.json
+++ b/donation-tracker/locales/de/translation.json
@@ -18,7 +18,7 @@
   "campaigns.listing.moreToCome": "Mehr demnächst",
   "campaigns.details.goBackButton": "Zurück",
   "campaigns.details.donations": "Spenden",
-  "campaigns.details.mobileTooltipHint": "Eine Zeile lange drücken um die ganze Beschreibung zu sehen",
+  "campaigns.details.mobileTooltipHint": "Eine Zeile lange drücken, um die ganze Beschreibung zu sehen",
   "campaigns.details.registerDonationButton": "Spende registrieren",
   "campaigns.details.dataRefreshInfo": "Die Daten werden ca. alle {{refreshMinutes}} Minuten im Hintergund aktualisiert - es kann also ein paar Minuten dauern bis Ihre Spendenregistrierung hier angezeiht wird."
 }

--- a/donation-tracker/locales/de/translation.json
+++ b/donation-tracker/locales/de/translation.json
@@ -14,7 +14,7 @@
   "imprint.dataPrivacy.content": "Wir nutzen Google Dienste (Google Forms &amp; Google Spreadsheets) um die Informationen was benötigt wird und was schon gespendet wurde zu verwalten.<br/>Das bedeutet das Google Ihre IP Adresse erhält und auch alle Eingaben in die verlinkten Formulare verarbeitet.<br/>Wir erfordern keinen Login um die Formulare auszufüllen, daher können sie die anonym bleiben indem Sie ein privates Browserfenster zum Ausfüllen benutzen.<br/>Um Ihre eingegebenen Daten zu löschen nachdem Sie diese übermittelt haben benötigen wir folgendes:<1><1>die URL des ausgefüllten Formular</1><1>Datum und Zeit der Übermittlung</1><1>die Daten die Sie übermittelt haben</1></1>Wir benötigen die übermittelten Daten in der Anfrage um den Datensatz eindeutig zu identifizieren - weil wir keine andere Möglichkeit haben einduetig herauszufinden wer was übermittelt hat.<br/>Bitte senden Sie die Anfrage an {{email}}",
   "imprint.imageContributions.title": "Bildbeiträge",
   "imprint.imageContributions.content": "Für die Bereitstellung der Bilder auf dieser Webseite danken wir:",
-  "campaigns.listing.moretocome": "Mehr demnächst",
+  "campaigns.listing.moreToCome": "Mehr demnächst",
   "campaigns.details.goBackButton": "Zurück",
   "campaigns.details.donations": "Spenden",
   "campaigns.details.mobileTooltipHint": "Eine Zeile lange drücken um die ganze Beschreibung zu sehen",

--- a/donation-tracker/locales/de/translation.json
+++ b/donation-tracker/locales/de/translation.json
@@ -14,5 +14,10 @@
   "imprint.dataPrivacy.content": "Wir nutzen Google Dienste (Google Forms &amp; Google Spreadsheets) um die Informationen was benötigt wird und was schon gespendet wurde zu verwalten.<br/>Das bedeutet das Google Ihre IP Adresse erhält und auch alle Eingaben in die verlinkten Formulare verarbeitet.<br/>Wir erfordern keinen Login um die Formulare auszufüllen, daher können sie die anonym bleiben indem Sie ein privates Browserfenster zum Ausfüllen benutzen.<br/>Um Ihre eingegebenen Daten zu löschen nachdem Sie diese übermittelt haben benötigen wir folgendes:<1><1>die URL des ausgefüllten Formular</1><1>Datum und Zeit der Übermittlung</1><1>die Daten die Sie übermittelt haben</1></1>Wir benötigen die übermittelten Daten in der Anfrage um den Datensatz eindeutig zu identifizieren - weil wir keine andere Möglichkeit haben einduetig herauszufinden wer was übermittelt hat.<br/>Bitte senden Sie die Anfrage an {{email}}",
   "imprint.imageContributions.title": "Bildbeiträge",
   "imprint.imageContributions.content": "Für die Bereitstellung der Bilder auf dieser Webseite danken wir:",
-  "campaigns.listing.moretocome": "Mehr demnächst"
+  "campaigns.listing.moretocome": "Mehr demnächst",
+  "campaigns.details.goBackButton": "Zurück",
+  "campaigns.details.donations": "Spenden",
+  "campaigns.details.mobileTooltipHint": "Eine Zeile lange drücken um die ganze Beschreibung zu sehen",
+  "campaigns.details.registerDonationButton": "Spende registrieren",
+  "campaigns.details.dataRefreshInfo": "Die Daten werden ca. alle {{refreshMinutes}} Minuten im Hintergund aktualisiert - es kann also ein paar Minuten dauern bis Ihre Spendenregistrierung hier angezeiht wird."
 }

--- a/donation-tracker/locales/de/translation.json
+++ b/donation-tracker/locales/de/translation.json
@@ -6,6 +6,7 @@
   "menu.start": "Start",
   "menu.about": "Über uns",
   "menu.imprint": "Impressum",
+  "menu.changeLanguage": "🇬🇧 English",
   "imprint.pageTitle": "Impressum",
   "imprint.legalContact": "Kontakt gem. TMG § 5",
   "imprint.cookiePolicy.title": "Cookie Informationen",

--- a/donation-tracker/locales/de/translation.json
+++ b/donation-tracker/locales/de/translation.json
@@ -13,5 +13,6 @@
   "imprint.dataPrivacy.title": "Datenschutz",
   "imprint.dataPrivacy.content": "Wir nutzen Google Dienste (Google Forms &amp; Google Spreadsheets) um die Informationen was benötigt wird und was schon gespendet wurde zu verwalten.<br/>Das bedeutet das Google Ihre IP Adresse erhält und auch alle Eingaben in die verlinkten Formulare verarbeitet.<br/>Wir erfordern keinen Login um die Formulare auszufüllen, daher können sie die anonym bleiben indem Sie ein privates Browserfenster zum Ausfüllen benutzen.<br/>Um Ihre eingegebenen Daten zu löschen nachdem Sie diese übermittelt haben benötigen wir folgendes:<1><1>die URL des ausgefüllten Formular</1><1>Datum und Zeit der Übermittlung</1><1>die Daten die Sie übermittelt haben</1></1>Wir benötigen die übermittelten Daten in der Anfrage um den Datensatz eindeutig zu identifizieren - weil wir keine andere Möglichkeit haben einduetig herauszufinden wer was übermittelt hat.<br/>Bitte senden Sie die Anfrage an {{email}}",
   "imprint.imageContributions.title": "Bildbeiträge",
-  "imprint.imageContributions.content": "Für die Bereitstellung der Bilder auf dieser Webseite danken wir:"
+  "imprint.imageContributions.content": "Für die Bereitstellung der Bilder auf dieser Webseite danken wir:",
+  "campaigns.listing.moretocome": "Mehr demnächst"
 }

--- a/donation-tracker/locales/en/translation.json
+++ b/donation-tracker/locales/en/translation.json
@@ -14,5 +14,10 @@
   "imprint.dataPrivacy.content": "We use services from Google (Google Forms & Google Spreadsheets) to manage the information about what things are needed and for the recording of what was already donated.<br/>This means that Google will receive your IP address and process the data you enter in the forms that are linked on this page.<br/>We do not require any sign in to fill out the forms, so you can do so anonymously via a private browser window.<br/>To delete your entered data after you submitted it we need the following:<1><1>URL of the form you filled</1><1>date and time ouf the form submission</1><1>the data that was entered</1></1>We need the details what you entered to make sure that we remove the correct dataset - as we have no way to identify who submitted what any other way.<br/>Please send your request to {{email}}.",
   "imprint.imageContributions.title": "Image Contributions",
   "imprint.imageContributions.content": "For beeing able to use the images on this website we want to thank:",
-  "campaigns.listing.moretocome": "More to come"
+  "campaigns.listing.moretocome": "More to come",
+  "campaigns.details.goBackButton": "Back",
+  "campaigns.details.donations": "Donations",
+  "campaigns.details.mobileTooltipHint": "Long-press a line if you want to see the full item description",
+  "campaigns.details.registerDonationButton": "Register donation",
+  "campaigns.details.dataRefreshInfo": "The data is refreshed in the background about every {{refreshMinutes}} minutes - so your registered donation may take a few minutes until it is shown here."
 }

--- a/donation-tracker/locales/en/translation.json
+++ b/donation-tracker/locales/en/translation.json
@@ -14,7 +14,7 @@
   "imprint.dataPrivacy.content": "We use services from Google (Google Forms & Google Spreadsheets) to manage the information about what things are needed and for the recording of what was already donated.<br/>This means that Google will receive your IP address and process the data you enter in the forms that are linked on this page.<br/>We do not require any sign in to fill out the forms, so you can do so anonymously via a private browser window.<br/>To delete your entered data after you submitted it we need the following:<1><1>URL of the form you filled</1><1>date and time ouf the form submission</1><1>the data that was entered</1></1>We need the details what you entered to make sure that we remove the correct dataset - as we have no way to identify who submitted what any other way.<br/>Please send your request to {{email}}.",
   "imprint.imageContributions.title": "Image Contributions",
   "imprint.imageContributions.content": "For beeing able to use the images on this website we want to thank:",
-  "campaigns.listing.moretocome": "More to come",
+  "campaigns.listing.moreToCome": "More to come",
   "campaigns.details.goBackButton": "Back",
   "campaigns.details.donations": "Donations",
   "campaigns.details.mobileTooltipHint": "Long-press a line if you want to see the full item description",

--- a/donation-tracker/locales/en/translation.json
+++ b/donation-tracker/locales/en/translation.json
@@ -13,5 +13,6 @@
   "imprint.dataPrivacy.title": "Data Privacy",
   "imprint.dataPrivacy.content": "We use services from Google (Google Forms & Google Spreadsheets) to manage the information about what things are needed and for the recording of what was already donated.<br/>This means that Google will receive your IP address and process the data you enter in the forms that are linked on this page.<br/>We do not require any sign in to fill out the forms, so you can do so anonymously via a private browser window.<br/>To delete your entered data after you submitted it we need the following:<1><1>URL of the form you filled</1><1>date and time ouf the form submission</1><1>the data that was entered</1></1>We need the details what you entered to make sure that we remove the correct dataset - as we have no way to identify who submitted what any other way.<br/>Please send your request to {{email}}.",
   "imprint.imageContributions.title": "Image Contributions",
-  "imprint.imageContributions.content": "For beeing able to use the images on this website we want to thank:"
+  "imprint.imageContributions.content": "For beeing able to use the images on this website we want to thank:",
+  "campaigns.listing.moretocome": "More to come"
 }

--- a/donation-tracker/locales/en/translation.json
+++ b/donation-tracker/locales/en/translation.json
@@ -6,6 +6,7 @@
   "menu.start": "Start",
   "menu.about": "About us",
   "menu.imprint": "Imprint",
+  "menu.changeLanguage": "🇩🇪 Deutsch",
   "imprint.pageTitle": "Imprint",
   "imprint.legalContact": "Contact as required by TMG § 5",
   "imprint.cookiePolicy.title": "Cookie Policy",

--- a/donation-tracker/locales/en/translation.json
+++ b/donation-tracker/locales/en/translation.json
@@ -18,7 +18,7 @@
   "campaigns.listing.moreToCome": "More to come",
   "campaigns.details.goBackButton": "Back",
   "campaigns.details.donations": "Donations",
-  "campaigns.details.mobileTooltipHint": "Long-press a line if you want to see the full item description",
+  "campaigns.details.mobileTooltipHint": "Long-press a line, if you want to see the full item description",
   "campaigns.details.registerDonationButton": "Register donation",
   "campaigns.details.dataRefreshInfo": "The data is refreshed in the background about every {{refreshMinutes}} minutes - so your registered donation may take a few minutes until it is shown here."
 }

--- a/donation-tracker/src/components/campaignListing.tsx
+++ b/donation-tracker/src/components/campaignListing.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useTranslation } from 'gatsby-plugin-react-i18next';
 
 import { Box, Typography } from '@mui/material';
 
@@ -13,6 +14,7 @@ interface Props {
 }
 
 const CampaignListing = ({ campaignTypes, statusType }: Props) => {
+  const { t } = useTranslation();
   const data = DataStore.getInstance();
   const campaigns = PageConfiguration.CampaignDetails.filter(({ CampaignType: campaignType }) => campaignTypes.includes(campaignType))
     .filter(({ Status: campaignStatus }) => (statusType === 'closed') === (campaignStatus === 'closed'))
@@ -29,7 +31,7 @@ const CampaignListing = ({ campaignTypes, statusType }: Props) => {
             </Box>
           ))
         ) : (
-          <Typography variant="h5">More to come</Typography>
+          <Typography variant="h5">{t('campaigns.listing.moretocome')}</Typography>
         )}
       </Box>
     </Box>

--- a/donation-tracker/src/components/campaignListing.tsx
+++ b/donation-tracker/src/components/campaignListing.tsx
@@ -31,7 +31,7 @@ const CampaignListing = ({ campaignTypes, statusType }: Props) => {
             </Box>
           ))
         ) : (
-          <Typography variant="h5">{t('campaigns.listing.moretocome')}</Typography>
+          <Typography variant="h5">{t('campaigns.listing.moreToCome')}</Typography>
         )}
       </Box>
     </Box>

--- a/donation-tracker/src/components/layout.tsx
+++ b/donation-tracker/src/components/layout.tsx
@@ -92,15 +92,15 @@ const LayoutModule = (props: any) => {
     event.preventDefault();
     setAnchorElShare(null);
     const languageIndex = languages.indexOf(language);
-    (languageIndex === 0) ? changeLanguage(languages[1]) : changeLanguage(languages[0]);
-  }
+    languageIndex === 0 ? changeLanguage(languages[1]) : changeLanguage(languages[0]);
+  };
   const generateOtherLanguageLink = () => {
     if (language === 'en') {
       return originalPath;
     } else {
       return '/en'.concat(originalPath);
     }
-  }
+  };
 
   const theme = createTheme({
     palette: {
@@ -238,15 +238,15 @@ const LayoutModule = (props: any) => {
                     {page.name}
                   </Button>
                 ))}
-                <Button
-                  href={generateOtherLanguageLink()}
-                  key="langSwitch"
-                  color="inherit"
-                  sx={{ my: 2, display: 'block', fontFamily: theme.typography.fontFamily }}
-                  onClick={event => handleLanguageSwitchClick(event)}
-                >
-                  {t('menu.changeLanguage')}
-                </Button>
+              <Button
+                href={generateOtherLanguageLink()}
+                key="langSwitch"
+                color="inherit"
+                sx={{ my: 2, display: 'block', fontFamily: theme.typography.fontFamily }}
+                onClick={event => handleLanguageSwitchClick(event)}
+              >
+                {t('menu.changeLanguage')}
+              </Button>
             </Box>
             <Box>
               <IconButton

--- a/donation-tracker/src/components/layout.tsx
+++ b/donation-tracker/src/components/layout.tsx
@@ -36,7 +36,7 @@ export const emailShareLink = () => {
 const titleText = PageConfiguration.pageTitle;
 
 const LayoutModule = (props: any) => {
-  const { navigate } = useI18next();
+  const { navigate, language, languages, changeLanguage, originalPath } = useI18next();
   const { t } = useTranslation();
 
   /* ToDo: import this from a central location */
@@ -86,6 +86,21 @@ const LayoutModule = (props: any) => {
     setAnchorElShare(null);
     window.open(itemLink(), '_blank');
   };
+
+  // ToDo: this two functions are is a quick hack for two languages to start with; needs to become better over time
+  const handleLanguageSwitchClick = (event: React.MouseEvent<HTMLElement>) => {
+    event.preventDefault();
+    setAnchorElShare(null);
+    const languageIndex = languages.indexOf(language);
+    (languageIndex === 0) ? changeLanguage(languages[1]) : changeLanguage(languages[0]);
+  }
+  const generateOtherLanguageLink = () => {
+    if (language === 'en') {
+      return originalPath;
+    } else {
+      return '/en'.concat(originalPath);
+    }
+  }
 
   const theme = createTheme({
     palette: {
@@ -196,6 +211,14 @@ const LayoutModule = (props: any) => {
                     <Typography textAlign="center">{page.name}</Typography>
                   </MenuItem>
                 ))}
+                <MenuItem
+                  href={generateOtherLanguageLink()}
+                  key="langSwitchMobile"
+                  color="default"
+                  onClick={event => handleLanguageSwitchClick(event)}
+                >
+                  {t('menu.changeLanguage')}
+                </MenuItem>
               </Menu>
             </Box>
             <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
@@ -215,6 +238,15 @@ const LayoutModule = (props: any) => {
                     {page.name}
                   </Button>
                 ))}
+                <Button
+                  href={generateOtherLanguageLink()}
+                  key="langSwitch"
+                  color="inherit"
+                  sx={{ my: 2, display: 'block', fontFamily: theme.typography.fontFamily }}
+                  onClick={event => handleLanguageSwitchClick(event)}
+                >
+                  {t('menu.changeLanguage')}
+                </Button>
             </Box>
             <Box>
               <IconButton

--- a/donation-tracker/src/modules/campaignDetails.tsx
+++ b/donation-tracker/src/modules/campaignDetails.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { isMobile } from 'react-device-detect';
-import { useTranslation, useI18next, I18nextContext } from 'gatsby-plugin-react-i18next';
+import { useTranslation, useI18next, I18nextContext, Trans } from 'gatsby-plugin-react-i18next';
 
 import { Box, Button, Container, Typography } from '@mui/material';
 import Card from '@mui/material/Card';
@@ -59,7 +59,7 @@ const CampaignDetailsModule = (props: { campaignKey: string; children: any }) =>
       <Container maxWidth="lg">
         <Box marginY={2}>
           <Button href={'/'} onClick={event => handleClickOnLink(event, '/')}>
-            <ChevronLeft /> Back
+            <ChevronLeft /> {t('campaigns.details.goBackButton')}
           </Button>
         </Box>
         <Card sx={{ flex: '0 1 500px', display: 'flex', flexDirection: 'column' }}>
@@ -76,7 +76,7 @@ const CampaignDetailsModule = (props: { campaignKey: string; children: any }) =>
             {donationItems.length > 0 && (
               <>
                 <Typography variant="h6" mt={2}>
-                  Donations / Spenden
+                  {t('campaigns.details.donations')}
                 </Typography>
                 <Typography variant="subtitle1" marginY={1}>
                   {shortDonationDescription}
@@ -99,14 +99,14 @@ const CampaignDetailsModule = (props: { campaignKey: string; children: any }) =>
             )}
             {isMobile && (
               <Typography component="div" sx={{ fontStyle: 'italic' }}>
-                Long-press a line if you want to see the full item description / Eine Zeile lange drücken um die ganze Beschreibung zu sehen
+                {t('campaigns.details.mobileTooltipHint')}
               </Typography>
             )}
           </CardContent>
           {campaign.RegistrationFormUrl && (
             <CardActions sx={{ justifyContent: 'center' }}>
               <Button variant="contained" href={campaign.RegistrationFormUrl} target="_blank">
-                Register donation / Spende registrieren
+                {t('campaigns.details.registerDonationButton')}
               </Button>
             </CardActions>
           )}
@@ -116,11 +116,7 @@ const CampaignDetailsModule = (props: { campaignKey: string; children: any }) =>
         {donationItems.length > 0 && PageConfiguration.AutoRefresh && (
           <>
             <Typography component="div" sx={{ fontStyle: 'italic' }}>
-              🇬🇧 The data is refreshed in the background about every {PageConfiguration.MaxDataAgeInMinutes} minutes - so your registered
-              donation may take a few minutes until it is shown here.
-              <br />
-              🇩🇪 Die Daten werden ca. alle {PageConfiguration.MaxDataAgeInMinutes} Minuten im Hintergund aktualisiert - es kann also ein
-              paar Minuten dauern bis Ihre Spendenregistrierung hier angezeiht wird.
+              <Trans i18nKey="campaigns.details.dataRefreshInfo" refreshMinutes={PageConfiguration.MaxDataAgeInMinutes}>...</Trans>
             </Typography>
             &nbsp;
             <UpdateNote />

--- a/donation-tracker/src/modules/campaignDetails.tsx
+++ b/donation-tracker/src/modules/campaignDetails.tsx
@@ -97,7 +97,7 @@ const CampaignDetailsModule = (props: { campaignKey: string; children: any }) =>
                 </table>
               </>
             )}
-            {(isMobile && donationItems.length > 0) && (
+            {isMobile && donationItems.length > 0 && (
               <Typography component="div" sx={{ fontStyle: 'italic' }}>
                 {t('campaigns.details.mobileTooltipHint')}
               </Typography>
@@ -116,7 +116,9 @@ const CampaignDetailsModule = (props: { campaignKey: string; children: any }) =>
         {donationItems.length > 0 && PageConfiguration.AutoRefresh && (
           <>
             <Typography component="div" sx={{ fontStyle: 'italic' }}>
-              <Trans i18nKey="campaigns.details.dataRefreshInfo" values={{refreshMinutes: PageConfiguration.MaxDataAgeInMinutes}}>...</Trans>
+              <Trans i18nKey="campaigns.details.dataRefreshInfo" values={{ refreshMinutes: PageConfiguration.MaxDataAgeInMinutes }}>
+                ...
+              </Trans>
             </Typography>
             &nbsp;
             <UpdateNote />

--- a/donation-tracker/src/modules/campaignDetails.tsx
+++ b/donation-tracker/src/modules/campaignDetails.tsx
@@ -116,7 +116,7 @@ const CampaignDetailsModule = (props: { campaignKey: string; children: any }) =>
         {donationItems.length > 0 && PageConfiguration.AutoRefresh && (
           <>
             <Typography component="div" sx={{ fontStyle: 'italic' }}>
-              <Trans i18nKey="campaigns.details.dataRefreshInfo" refreshMinutes={PageConfiguration.MaxDataAgeInMinutes}>...</Trans>
+              <Trans i18nKey="campaigns.details.dataRefreshInfo" values={{refreshMinutes: PageConfiguration.MaxDataAgeInMinutes}}>...</Trans>
             </Typography>
             &nbsp;
             <UpdateNote />

--- a/donation-tracker/src/modules/campaignDetails.tsx
+++ b/donation-tracker/src/modules/campaignDetails.tsx
@@ -97,7 +97,7 @@ const CampaignDetailsModule = (props: { campaignKey: string; children: any }) =>
                 </table>
               </>
             )}
-            {isMobile && (
+            {(isMobile && donationItems.length > 0) && (
               <Typography component="div" sx={{ fontStyle: 'italic' }}>
                 {t('campaigns.details.mobileTooltipHint')}
               </Typography>

--- a/donation-tracker/src/modules/imprint.tsx
+++ b/donation-tracker/src/modules/imprint.tsx
@@ -47,7 +47,7 @@ const ImprintModule = (props: any) => {
           <CardHeader title={t('imprint.dataPrivacy.title')} />
           <CardContent>
             <Typography component="div">
-              <Trans i18nKey="imprint.dataPrivacy.content" email={PageConfiguration.ImprintContact.PrivacyEmail}>
+              <Trans i18nKey="imprint.dataPrivacy.content" values={{email: PageConfiguration.ImprintContact.PrivacyEmail}}>
                 ...
                 <ul>
                   <li>...</li>

--- a/donation-tracker/src/modules/imprint.tsx
+++ b/donation-tracker/src/modules/imprint.tsx
@@ -47,7 +47,7 @@ const ImprintModule = (props: any) => {
           <CardHeader title={t('imprint.dataPrivacy.title')} />
           <CardContent>
             <Typography component="div">
-              <Trans i18nKey="imprint.dataPrivacy.content" values={{email: PageConfiguration.ImprintContact.PrivacyEmail}}>
+              <Trans i18nKey="imprint.dataPrivacy.content" values={{ email: PageConfiguration.ImprintContact.PrivacyEmail }}>
                 ...
                 <ul>
                   <li>...</li>

--- a/donation-tracker/src/pages/en/index.tsx
+++ b/donation-tracker/src/pages/en/index.tsx
@@ -96,7 +96,7 @@ const IndexPage = () => {
         </Typography>
         <Typography>🚜💙💛</Typography>
         <Typography paragraph={true}>
-          We are a group of employees who work in Ingelheim, Germany. We joined our forces in April 2022 to actively support people in
+          We are a group of colleagues who work in Ingelheim, Germany. We joined our forces in April 2022 to actively support people in
           Ukraine affected by the russian invasion.
         </Typography>
         <Typography paragraph={true}>

--- a/donation-tracker/src/pages/index.tsx
+++ b/donation-tracker/src/pages/index.tsx
@@ -25,7 +25,7 @@ const IndexPage = () => {
       &nbsp;
       <Container maxWidth="lg">
         <Card>
-          <CardHeader title={PageConfiguration.pageTitle} subheader="How can we help people in Ukraine affected by war?"></CardHeader>
+          <CardHeader title={PageConfiguration.pageTitle} subheader="Wie können wir den vom Krieg betroffenen Menschen in der Ukraine helfen?"></CardHeader>
           <CardMedia>
             <StaticImage
               src="../images/ehimetalor-akhere-unuabona-6hzWwYioEo4-unsplash.jpg"


### PR DESCRIPTION
- `campaignDetails.tsx`:
  - tap for details message no longer visible if there are no item in the list (on mobile)
  - fully translated
- `campaignListing.tsx` -> i18n for "More to come"
- `pages/index.tsx` -> Sub-Header now also translated
- `layout.tsx` -> added language toggle
- `modules/imprint.tsx` -> fixed not working replacement of the {{email}} placeholder

<img width="887" alt="Screenshot 2022-05-14 at 11 56 49" src="https://user-images.githubusercontent.com/14804960/168420871-addab2e5-c672-40a8-b8de-6f4d623b1aa1.png">
<img width="375" alt="Screenshot 2022-05-14 at 11 59 09" src="https://user-images.githubusercontent.com/14804960/168420973-cd718aa6-dc2d-4268-ad3d-ce92bf6c4a43.png">

